### PR TITLE
eliminate react duplicate key error

### DIFF
--- a/packages/app/src/components/Dashboard/PayoutModsList.tsx
+++ b/packages/app/src/components/Dashboard/PayoutModsList.tsx
@@ -89,9 +89,9 @@ export default function PayoutModsList({
   return (
     <div>
       {mods?.length ? (
-        mods.map(m => (
+        mods.map((m, i) => (
           <div
-            key={m.beneficiary ?? '' + m.percent}
+            key={`${m.beneficiary ?? '' + m.percent}-${i}`}
             style={{
               display: 'flex',
               alignItems: 'baseline',

--- a/packages/app/src/components/Dashboard/PayoutModsList.tsx
+++ b/packages/app/src/components/Dashboard/PayoutModsList.tsx
@@ -91,7 +91,7 @@ export default function PayoutModsList({
       {mods?.length ? (
         mods.map((m, i) => (
           <div
-            key={`${m.beneficiary ?? '' + m.percent}-${i}`}
+            key={`${m.beneficiary ?? m.percent}-${i}`}
             style={{
               display: 'flex',
               alignItems: 'baseline',


### PR DESCRIPTION
When there are multiple recipients with the same address or percent, react throws duplicate key errors. This eliminates them.

```
  index.js:1 Warning: Encountered two children with the same key, `****`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```