### PR TITLE
bugfixes for responsive layout on project page

### DIFF
--- a/packages/app/src/components/Dashboard/ProjectActivity.tsx
+++ b/packages/app/src/components/Dashboard/ProjectActivity.tsx
@@ -214,7 +214,7 @@ export default function ProjectActivity() {
         </div>
       </div>
 
-      <div style={{ display: 'flex', marginTop: 5 }}>
+      <div style={{ display: 'flex', marginTop: 5, overflowX: 'scroll' }}>
         <RichImgPreview src={parseLink(e.note)} style={{ marginRight: 10 }} />
 
         <div

--- a/packages/app/src/components/Dashboard/ProjectHeader.tsx
+++ b/packages/app/src/components/Dashboard/ProjectHeader.tsx
@@ -28,6 +28,9 @@ export default function ProjectHeader() {
       <div
         style={{
           display: 'flex',
+          flexWrap: 'wrap',
+          justifyContent: 'space-between',
+          alignItems: 'center',
         }}
       >
         <div style={{ marginRight: 20, height: '100%' }}>
@@ -39,17 +42,40 @@ export default function ProjectHeader() {
         </div>
 
         <div style={{ flex: 1 }}>
-          <h1
+          <div
             style={{
-              fontSize: '2.4rem',
-              margin: 0,
-              color: metadata?.name
-                ? colors.text.primary
-                : colors.text.placeholder,
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
             }}
           >
-            {metadata?.name || 'Untitled project'}
-          </h1>
+            <h1
+              style={{
+                fontSize: '2.4rem',
+                margin: 0,
+                color: metadata?.name
+                  ? colors.text.primary
+                  : colors.text.placeholder,
+              }}
+            >
+              {metadata?.name || 'Untitled project'}
+            </h1>
+
+            <div>
+              <Button
+                onClick={() => setToolDrawerVisible(true)}
+                icon={<ToolOutlined />}
+                type="text"
+              ></Button>
+              {isOwner && (
+                <Button
+                  onClick={() => setEditProjectModalVisible(true)}
+                  icon={<SettingOutlined />}
+                  type="text"
+                ></Button>
+              )}
+            </div>
+          </div>
 
           <h3>
             <Space size="middle">
@@ -86,7 +112,6 @@ export default function ProjectHeader() {
             display: 'flex',
             justifyContent: 'space-between',
             flexDirection: 'column',
-            height: headerHeight,
             marginLeft: 20,
           }}
         >
@@ -98,21 +123,6 @@ export default function ProjectHeader() {
             }}
           >
             ID: {projectId.toNumber()}
-          </div>
-
-          <div>
-            <Button
-              onClick={() => setToolDrawerVisible(true)}
-              icon={<ToolOutlined />}
-              type="text"
-            ></Button>
-            {isOwner && (
-              <Button
-                onClick={() => setEditProjectModalVisible(true)}
-                icon={<SettingOutlined />}
-                type="text"
-              ></Button>
-            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Just some small layout bugs I notice when I visit a project page on my iPhone:

![before_0](https://user-images.githubusercontent.com/1292831/128951664-69b802c2-dbdf-4096-93c6-966d708cf9df.png)

Kind of hard to tell from the screenshot, but the page scrolls horizontally. Here's with the changes:

![new](https://user-images.githubusercontent.com/1292831/128954722-e3450021-9a86-4dd7-bf19-3744fed085f9.png)

